### PR TITLE
🎨 Update OpenAI SKU name to 'GlobalStandard'

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -73,7 +73,7 @@ module openAi 'core/ai/cognitiveservices.bicep' = {
           version: openAiDeploymentVersion
         }
         sku: {
-          name: 'Standard'
+          name: 'GlobalStandard'
           capacity: openAiDeploymentCapacity
         }
       }


### PR DESCRIPTION
Changed the OpenAI SKU name from `Standard` to `GlobalStandard` as the latter is more generally available.